### PR TITLE
[PRD-289] Adding `get_payments_by_order_id` client in Razorpay

### DIFF
--- a/lib/active_merchant/billing/gateways/razorpay.rb
+++ b/lib/active_merchant/billing/gateways/razorpay.rb
@@ -34,6 +34,13 @@ module ActiveMerchant #:nodoc:
           parameters[:authorization_id] = payment_id
           commit(:get, 'fetch', parameters)
         end
+
+        def get_payments_by_order_id(order_id, options={})
+          return Response.new(false, 'Order ID is mandatory') if order_id.empty?
+          parameters = {}
+          parameters[:authorization_id] = order_id
+          commit(:get, 'fetch_payments_by_order', parameters)
+        end
   
         def capture(money, payment_id, options={})
           return Response.new(false, 'Payment ID is mandatory') if payment_id.empty?
@@ -81,6 +88,8 @@ module ActiveMerchant #:nodoc:
             "payments/#{parameters[:authorization_id]}/capture"
           when 'fetch'
             "payments/#{parameters[:authorization_id]}"
+          when 'fetch_payments_by_order'
+            "orders/#{parameters[:authorization_id]}/payments"
           end
         end
 

--- a/test/remote/gateways/remote_razorpay_test.rb
+++ b/test/remote/gateways/remote_razorpay_test.rb
@@ -5,6 +5,7 @@ class RemoteRazorpayTest < Test::Unit::TestCase
     @gateway = RazorpayGateway.new(fixtures(:razorpay))
 
     @amount = 10000
+    @order_id = 'order_HziMBC148n2VxU'
     @payment_id = 'pay_HziML4B8Uybcvr'
     @unauthorized_payment_id = 'pay_HyQdXlAAwUuNxt'
     @invalid_payment_id = 'pay_HnTllcQFCxVGNU'
@@ -80,6 +81,14 @@ class RemoteRazorpayTest < Test::Unit::TestCase
     response = gateway.capture(@amount, @payment_id, @options)
     assert_failure response
     assert_match "The api key provided is invalid", response.message
+  end
+
+  def test_successful_order_fetch
+    response = @gateway.get_payments_by_order_id(@order_id)
+    assert_success response
+    assert_equal "collection", response.params["entity"]
+    assert_equal 1, response.params["items"].length()
+    assert_equal @order_id, response.params["items"][0]["order_id"]
   end
 
   def test_successful_payment_fetch

--- a/test/remote/gateways/remote_razorpay_test.rb
+++ b/test/remote/gateways/remote_razorpay_test.rb
@@ -5,7 +5,8 @@ class RemoteRazorpayTest < Test::Unit::TestCase
     @gateway = RazorpayGateway.new(fixtures(:razorpay))
 
     @amount = 10000
-    @order_id = 'order_HziMBC148n2VxU'
+    @order_id = 'order_12345trewq6543'
+    @invalid_order_id = 'order_HziMBC148n2VXu'
     @payment_id = 'pay_HziML4B8Uybcvr'
     @unauthorized_payment_id = 'pay_HyQdXlAAwUuNxt'
     @invalid_payment_id = 'pay_HnTllcQFCxVGNU'
@@ -89,6 +90,20 @@ class RemoteRazorpayTest < Test::Unit::TestCase
     assert_equal "collection", response.params["entity"]
     assert_equal 1, response.params["items"].length()
     assert_equal @order_id, response.params["items"][0]["order_id"]
+    assert response.params["items"][0]["id"] != nil
+  end
+
+  def test_order_fetch_when_order_id_not_provided_then_400
+    response = @gateway.get_payments_by_order_id('')
+    assert_failure response
+    assert_match 'Order ID is mandatory', response.message
+  end
+
+  def test_order_fetch_when_invalid_order_id_provided_then_400
+    response = @gateway.get_payments_by_order_id(@invalid_order_id)
+    assert_success response
+    assert_equal "collection", response.params["entity"]
+    assert_equal 0, response.params["count"]
   end
 
   def test_successful_payment_fetch


### PR DESCRIPTION
### Jira Ticket: [PRD-289](https://inai.atlassian.net/browse/PRD-289)

### Description:

- adds client for fetching payments by associated order_id

### Testing:

Adds integration test for the API. 