### PR TITLE
[PRD-1182] Adding verify creds for Midtrans

### DIFF
--- a/lib/active_merchant/billing/gateways/midtrans.rb
+++ b/lib/active_merchant/billing/gateways/midtrans.rb
@@ -141,6 +141,15 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def verify_credentials()
+        options = {}
+        transaction_details = {}
+        transaction_details[:gross_amount] = MINIMUM_AUTHORIZE_AMOUNTS['IDR']
+        transaction_details[:order_id] = generate_unique_id()
+        options[:transaction_details] = transaction_details
+        commit('verify_credentials', options)
+      end
+
       private
 
       def add_customer_data(post, options)
@@ -220,6 +229,8 @@ module ActiveMerchant #:nodoc:
             gateway_response = @midtrans_gateway.cancel(parameters[:transaction_id])
           when "refund"
             gateway_response = @midtrans_gateway.refund(parameters[:transaction_id], parameters[:details])
+          when "verify_credentials"
+            gateway_response = @midtrans_gateway.create_snap_token(parameters)
           end
           response_for(gateway_response)
         rescue MidtransError => error

--- a/test/remote/gateways/remote_midtrans_test.rb
+++ b/test/remote/gateways/remote_midtrans_test.rb
@@ -254,4 +254,27 @@ class RemoteMidtransTest < Test::Unit::TestCase
     assert_equal authorize_response.params["status_code"], "411"
     assert_equal authorize_response.message, "Credit card token is no longer available. Please create a new one."
   end
+
+  def test_verify_credentials_when_valid_creds_then_success
+    response = @gateway.verify_credentials()
+    assert_success response
+  end
+
+  def test_verify_credentials_when_invalid_creds_then_failure
+    # Invalid server key
+    invalid_gateway = MidtransGateway.new(
+      :client_key => fixtures(:midtrans)[:client_key],
+      :server_key => "dummy"
+    )
+    response = invalid_gateway.verify_credentials()
+    assert_failure response
+
+    # Invalid client key
+    invalid_gateway = MidtransGateway.new(
+      :client_key => "dummy",
+      :server_key => fixtures(:midtrans)[:server_key]
+    )
+    response = invalid_gateway.verify_credentials()
+    assert_failure response
+  end
 end


### PR DESCRIPTION
### Jira Ticket: [PRD-1182](https://inai.atlassian.net/browse/PRD-1182)

### Description:

- adds `verify_credentials` API for midtrans

### Testing:

- adds tests asserting the changes for various scenarios.

> **The `server_key` validation is alone added. Couldn't find a supporting API to validate the `client_key`. Have raised a query with their support regarding the same**