### PR TITLE
[PRD-3283] Changes to accessing saved token from Braintree if payment nonce is saved instead of card

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -278,11 +278,18 @@ module ActiveMerchant #:nodoc:
             device_data: options[:device_data]
           }.merge credit_card_params
           result = @braintree_gateway.customer.create(merge_credit_card_options(parameters, options))
+          if result.success?
+            if options[:payment_method_nonce]
+              credit_card_token = result.customer.paypal_accounts[0].token
+            else
+              credit_card_token = result.customer.credit_cards[0].token
+            end
+          end
           Response.new(result.success?, message_from_result(result),
             {
               braintree_customer: (customer_hash(result.customer, :include_credit_cards) if result.success?),
               customer_vault_id: (result.customer.id if result.success?),
-              credit_card_token: (result.customer.credit_cards[0].token if result.success?)
+              credit_card_token: (credit_card_token if result.success?)
             },
             authorization: (result.customer.id if result.success?),
             error_code: error_code_from_result(result))

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -280,16 +280,16 @@ module ActiveMerchant #:nodoc:
           result = @braintree_gateway.customer.create(merge_credit_card_options(parameters, options))
           if result.success?
             if options[:payment_method_nonce]
-              credit_card_token = result.customer.paypal_accounts[0].token
+              saved_token = result.customer.paypal_accounts[0].token
             else
-              credit_card_token = result.customer.credit_cards[0].token
+              saved_token = result.customer.credit_cards[0].token
             end
           end
           Response.new(result.success?, message_from_result(result),
             {
               braintree_customer: (customer_hash(result.customer, :include_credit_cards) if result.success?),
               customer_vault_id: (result.customer.id if result.success?),
-              credit_card_token: (credit_card_token if result.success?)
+              credit_card_token: (saved_token if result.success?)
             },
             authorization: (result.customer.id if result.success?),
             error_code: error_code_from_result(result))


### PR DESCRIPTION
- If we save a payment method nonce instead of card, PayPal stores it in the customer object's _paypal_accounts_ key instead of in _credit_cards_ . This PR makes changes for this usecase