### PR TITLE
[PRD-3387]  Fix saving paypal account for an existing customer in braintree

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -282,18 +282,22 @@ module ActiveMerchant #:nodoc:
             if options[:payment_method_nonce]
               if not result.customer.paypal_accounts.empty?
                 saved_token = result.customer.paypal_accounts[0].token
+                email = result.customer.paypal_accounts[0].email
               else
                 saved_token = result.customer.credit_cards[0].token
+                email = result.customer.credit_cards[0].email
               end
             else
               saved_token = result.customer.credit_cards[0].token
+              email = result.customer.credit_cards[0].email
             end
           end
           Response.new(result.success?, message_from_result(result),
             {
               braintree_customer: (customer_hash(result.customer, :include_credit_cards) if result.success?),
               customer_vault_id: (result.customer.id if result.success?),
-              credit_card_token: (saved_token if result.success?)
+              credit_card_token: (saved_token if result.success?),
+              email: (email if result.success?),
             },
             authorization: (result.customer.id if result.success?),
             error_code: error_code_from_result(result))
@@ -325,15 +329,16 @@ module ActiveMerchant #:nodoc:
             parameters[:billing_address] = address unless address.all? { |_k, v| empty?(v) }
           end
 
-          result = @braintree_gateway.credit_card.create(parameters)
+          result = @braintree_gateway.payment_method.create(parameters)
           ActiveMerchant::Billing::Response.new(
             result.success?,
             message_from_result(result),
             {
-              customer_vault_id: (result.credit_card.customer_id if result.success?),
-              credit_card_token: (result.credit_card.token if result.success?)
+              customer_vault_id: (result.payment_method.customer_id if result.success?),
+              credit_card_token: (result.payment_method.token if result.success?),
+              email: (result.payment_method.email if result.success?)
             },
-            authorization: (result.credit_card.customer_id if result.success?),
+            authorization: (result.payment_method.customer_id if result.success?),
             error_code: error_code_from_result(result)
           )
         end

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -285,11 +285,11 @@ module ActiveMerchant #:nodoc:
                 email = result.customer.paypal_accounts[0].email
               else
                 saved_token = result.customer.credit_cards[0].token
-                email = result.customer.credit_cards[0].email
+                email = nil
               end
             else
               saved_token = result.customer.credit_cards[0].token
-              email = result.customer.credit_cards[0].email
+              email = nil
             end
           end
           Response.new(result.success?, message_from_result(result),
@@ -330,13 +330,21 @@ module ActiveMerchant #:nodoc:
           end
 
           result = @braintree_gateway.payment_method.create(parameters)
+          if result.success?
+            if result.payment_method.instance_variable_defined?(:@email)
+              email = result.payment_method.email
+            else
+              email = nil
+            end
+          end
+
           ActiveMerchant::Billing::Response.new(
             result.success?,
             message_from_result(result),
             {
               customer_vault_id: (result.payment_method.customer_id if result.success?),
               credit_card_token: (result.payment_method.token if result.success?),
-              email: (result.payment_method.email if result.success?)
+              email: (email if result.success?)
             },
             authorization: (result.payment_method.customer_id if result.success?),
             error_code: error_code_from_result(result)

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -279,17 +279,16 @@ module ActiveMerchant #:nodoc:
           }.merge credit_card_params
           result = @braintree_gateway.customer.create(merge_credit_card_options(parameters, options))
           if result.success?
+            email = nil
             if options[:payment_method_nonce]
               if not result.customer.paypal_accounts.empty?
                 saved_token = result.customer.paypal_accounts[0].token
                 email = result.customer.paypal_accounts[0].email
               else
                 saved_token = result.customer.credit_cards[0].token
-                email = nil
               end
             else
               saved_token = result.customer.credit_cards[0].token
-              email = nil
             end
           end
           Response.new(result.success?, message_from_result(result),


### PR DESCRIPTION
**Description:**

- Modifies add payment method to existing customer logic so that _payment_method.create_ method is used instead of _credit_card.create_. This is required since the add logic fails when a paypal account is attempted to be added for an existing user
- Adds `email` in API response. This will be used for creating fingerprint for paypal payments